### PR TITLE
Remove transition from failed to in-progress

### DIFF
--- a/transaction.py
+++ b/transaction.py
@@ -230,7 +230,6 @@ class PaymentTransaction(Workflow, ModelSQL, ModelView):
             ('in-progress', 'authorized'),
             ('in-progress', 'completed'),
             ('in-progress', 'cancel'),
-            ('failed', 'in-progress'),
             ('authorized', 'cancel'),
             ('authorized', 'completed'),
             ('completed', 'posted'),


### PR DESCRIPTION
From all the gateways written so far, this case is as
rare as the walking dead. So remove the transition
before someone uses the case